### PR TITLE
fix: shadow to css not using shadows opacity

### DIFF
--- a/src/transforms/CSSHelper.ts
+++ b/src/transforms/CSSHelper.ts
@@ -194,7 +194,14 @@ export class CSSHelper {
     }
     return `${value.type === ShadowType.inner ? 'inset ' : ''}${value.x}px ${value.y}px ${value.radius}px ${
       value.spread
-    }px ${this.colorTokenValueToCSS(value.color, allTokens, options)}`
+    }px ${this.colorTokenValueToCSS(
+      {
+        ...value.color,
+        opacity: value.opacity
+      },
+      allTokens,
+      options
+    )}`
   }
 
   static stringTokenValueToCSS(
@@ -277,7 +284,9 @@ export class CSSHelper {
         : undefined,
       caps: typography.textCase.value === TextCase.smallCaps,
       fontSize: this.dimensionTokenValueToCSS(typography.fontSize, allTokens, options),
-      lineHeight: typography.lineHeight ? this.dimensionTokenValueToCSS(typography.lineHeight, allTokens, options) : undefined
+      lineHeight: typography.lineHeight
+        ? this.dimensionTokenValueToCSS(typography.lineHeight, allTokens, options)
+        : undefined
     }
 
     // Formal CSS definition: font-style, font-variant, font-weight, font-stretch, font-size, line-height, and font-family.

--- a/tests/transforms/CSSHelper.test.ts
+++ b/tests/transforms/CSSHelper.test.ts
@@ -178,7 +178,14 @@ const testTypography: TypographyTokenValue = {
 }
 
 const testShadow: ShadowTokenValue = {
-  color: testColor,
+  color: {
+    ...testColor,
+    opacity: {
+      measure: 1,
+      referencedTokenId: null,
+      unit: Unit.raw
+    }
+  },
   x: 3,
   y: 4,
   radius: 5,
@@ -541,7 +548,5 @@ test('toCSS_typographyToken_7', () => {
     ...testTypography,
     lineHeight: null
   }
-  expect(CSSHelper.typographyTokenValueToCSS(typography, tokens, testOptions)).toBe(
-    '"400" 16px "Arial"'
-  )
+  expect(CSSHelper.typographyTokenValueToCSS(typography, tokens, testOptions)).toBe('"400" 16px "Arial"')
 })


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you are adding a new helper utility or expanding existing utility, explain what it does. -->

The utility currently uses the opacity from color, but shadow has its own opacity.

Here's an example where all colors have opacity of 1/100% with a shadow opacity of 0.16/16%
<img width="1155" alt="Screenshot 2024-03-18 at 5 58 07 PM" src="https://github.com/Supernova-Studio/export-helpers/assets/8062245/5d8de668-5464-476e-a430-d8806fbe2994">

And the current implementation outputs `0px 0px 0px 1px #000000`.


## Usage

<!-- An example code how your utility will be used. Utilities should be reusable, benefiting all the users, so make sure you show it on the case that other might encounter. Keep in mind that helpers which are specific to a single exporter are much better situed for inclusion in that specific exporter rather than generic library used by everyone.  -->

## Checklist

- [ ] I included doc comments for any utility I am adding
- [ ] I wrote test for any utility I am adding and the tests cover use-cases reasonably
- [ ] I made sure the helper was not built before
- [ ] I run `npm run build` to make sure helper is buildable locally
- [ ] I run `npm run test` to make sure all helpers still work
- [ ] I run `npm run lint` to make sure there are no linting errors (run `npm run pretty` to autofix all issues)

<!-- Check all above to confirm you did all the steps!  -->


