### PR TITLE
Fix the values for option tokens (textDecoration, textCase, visibility)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@supernovaio/export-helpers",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@supernovaio/export-helpers",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@supernovaio/sdk-exporters": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovaio/export-helpers",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Supernova.io Export Helpers and Utilities",
   "main": "./build/helpers.js",
   "types": "./build/types/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supernovaio/export-helpers",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Supernova.io Export Helpers and Utilities",
   "main": "./build/helpers.js",
   "types": "./build/types/src/index.d.ts",

--- a/src/transforms/CSSHelper.ts
+++ b/src/transforms/CSSHelper.ts
@@ -83,9 +83,11 @@ export class CSSHelper {
       case TokenType.string:
         return this.stringTokenValueToCSS((token as AnyStringToken).value, allTokens, options)
       case TokenType.textCase:
+        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.textDecoration:
+        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.visibility:
-        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options)
+        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.blur:
         return this.blurTokenValueToCSS((token as BlurToken).value, allTokens, options)
       case TokenType.typography:
@@ -233,13 +235,22 @@ export class CSSHelper {
   static optionTokenValueToCSS(
     option: AnyOptionTokenValue,
     allTokens: Map<string, Token>,
-    options: TokenToCSSOptions
+    options: TokenToCSSOptions,
+    tokenType: TokenType
   ): string {
     const reference = sureOptionalReference(option.referencedTokenId, allTokens, options.allowReferences)
     if (reference) {
       return options.tokenToVariableRef(reference)
     }
-    return `"${option.value}"`
+    if (tokenType === TokenType.textCase) {
+      return this.textCaseToCSS(option.value as TextCase)
+    }
+    if (tokenType === TokenType.textDecoration) {
+      return this.textDecorationToCSS(option.value as TextDecoration)
+    }
+
+    // Visibility values are supported in CSS as is our data model
+    return option.value
   }
 
   static blurTokenValueToCSS(blur: BlurTokenValue, allTokens: Map<string, Token>, options: TokenToCSSOptions): string {

--- a/src/transforms/CSSHelper.ts
+++ b/src/transforms/CSSHelper.ts
@@ -83,9 +83,7 @@ export class CSSHelper {
       case TokenType.string:
         return this.stringTokenValueToCSS((token as AnyStringToken).value, allTokens, options)
       case TokenType.textCase:
-        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.textDecoration:
-        return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.visibility:
         return this.optionTokenValueToCSS((token as AnyOptionToken).value, allTokens, options, token.tokenType)
       case TokenType.blur:

--- a/tests/transforms/CSSHelper.test.ts
+++ b/tests/transforms/CSSHelper.test.ts
@@ -454,14 +454,14 @@ test('toCSS_optionToken_2', () => {
   expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textCase)).toBe('var(--optionRef)')
 })
 
-test('toCSS_optionToken_2', () => {
+test('toCSS_optionTextDecorationToken_1', () => {
   let option = {
     ...testOptionTextDecoration
   }
   expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textDecoration)).toBe('underline')
 })
 
-test('toCSS_optionToken_2', () => {
+test('toCSS_optionTextDecorationToken_2', () => {
   let option = {
     ...testOptionTextDecoration,
     value: TextDecoration.strikethrough

--- a/tests/transforms/CSSHelper.test.ts
+++ b/tests/transforms/CSSHelper.test.ts
@@ -23,6 +23,7 @@ import {
   TextCase,
   TextDecoration,
   Token,
+  TokenType,
   TypographyToken,
   Unit
 } from '@supernovaio/sdk-exporters'
@@ -106,6 +107,12 @@ const testOption: AnyOptionTokenValue = {
   value: TextCase.lower,
   referencedTokenId: null,
   options: [TextCase.lower, TextCase.upper]
+}
+
+const testOptionTextDecoration: AnyOptionTokenValue = {
+  value: TextDecoration.underline,
+  referencedTokenId: null,
+  options: [TextDecoration.original, TextDecoration.underline, TextDecoration.strikethrough]
 }
 
 const testGradient: GradientTokenValue = {
@@ -436,7 +443,7 @@ test('toCSS_optionToken_1', () => {
   let option = {
     ...testOption
   }
-  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions)).toBe('"Lower"')
+  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textCase)).toBe('lowercase')
 })
 
 test('toCSS_optionToken_2', () => {
@@ -444,7 +451,22 @@ test('toCSS_optionToken_2', () => {
     ...testOption,
     referencedTokenId: 'optionRef'
   }
-  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions)).toBe('var(--optionRef)')
+  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textCase)).toBe('var(--optionRef)')
+})
+
+test('toCSS_optionToken_2', () => {
+  let option = {
+    ...testOptionTextDecoration
+  }
+  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textDecoration)).toBe('underline')
+})
+
+test('toCSS_optionToken_2', () => {
+  let option = {
+    ...testOptionTextDecoration,
+    value: TextDecoration.strikethrough
+  }
+  expect(CSSHelper.optionTokenValueToCSS(option, tokens, testOptions, TokenType.textDecoration)).toBe('line-through')
 })
 
 test('toCSS_blurToken_1', () => {


### PR DESCRIPTION
## Description
Change the textDecoration, textCase, and visibility token values to return correct CSS values for these CSS properties. 

## Checklist

- [x] I included doc comments for any utility I am adding
- [x] I wrote test for any utility I am adding and the tests cover use-cases reasonably
- [x] I made sure the helper was not built before
- [x] I run `npm run build` to make sure helper is buildable locally
- [x] I run `npm run test` to make sure all helpers still work
- [x] I run `npm run lint` to make sure there are no linting errors (run `npm run pretty` to autofix all issues)
